### PR TITLE
Update explorer links to use auto generated links

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -6,7 +6,7 @@ to how the object gets serialized from the server to the client, but also attach
 functionality and behaviors to the object. Components may react to game messages but also express
 other aspects of the game.
 
-As per `this test object's description <https://explorer.lu/objects/6228>`_,
+As per :lot:`this test object's description <3050>`,
 the internal name of a component class would have been :file:`LWO{Name}Component` as in
 :samp:`LWOModelBuilderComponent`.
 

--- a/docs/components/061-module-assembly.rst
+++ b/docs/components/061-module-assembly.rst
@@ -4,8 +4,8 @@ Module Assembly Component (61)
 This component is attached to any object which can be constructed
 from multiple part. For the live game, this were only
 
-* `Custom Modular Rocket Ship (6416) <https://explorer.lu/objects/6416>`_
-* `Custom Racing Car (8092) <https://explorer.lu/objects/8092>`_
+* :lot:`Custom Modular Rocket Ship (6416) <6416>`
+* :lot:`Custom Racing Car (8092) <8092>`
 
 as well as some testing objects.
 

--- a/docs/components/066-hf-light-direction-gadget.rst
+++ b/docs/components/066-hf-light-direction-gadget.rst
@@ -4,4 +4,4 @@ HFLightDirectionGadget Component (66)
 HappyFlower (HF) was the world editor within the game. It seems
 to only be attached to a single object responsible for setting
 the environment light direction. That object is
-`HF Light Direction Gadget <https://explorer.lu/objects/6968>`_.
+:lot:`HF Light Direction Gadget <6968>`.

--- a/docs/components/077-sound-trigger.rst
+++ b/docs/components/077-sound-trigger.rst
@@ -4,5 +4,5 @@ Sound Trigger Component (77)
 Triggers music/sound for objects colliding with / within the object.
 There are exactly 2 objects with this component:
 
-* `SOUND TRIGGER -- BOX <https://explorer.lu/objects/9741>`_
-* `SOUND TRIGGER -- SPHERE <https://explorer.lu/objects/9742>`_
+* :lot:`SOUND TRIGGER -- BOX <9741>`
+* :lot:`SOUND TRIGGER -- SPHERE <9742>`

--- a/docs/components/079-racing-sound-trigger.rst
+++ b/docs/components/079-racing-sound-trigger.rst
@@ -4,5 +4,5 @@ Racing Sound Trigger Component (79)
 Triggers music/sound for objects colliding with / within the object.
 There are exactly 2 objects with this component:
 
-* `SOUND TRIGGER (for Racing) -- BOX <https://explorer.lu/objects/9862>`_
-* `SOUND TRIGGER (for Racing) -- SPHERE <https://explorer.lu/objects/9863>`_
+* :lot:`SOUND TRIGGER (for Racing) -- BOX <9862>`
+* :lot:`SOUND TRIGGER (for Racing) -- SPHERE <9863>`

--- a/docs/components/095-user-control.rst
+++ b/docs/components/095-user-control.rst
@@ -2,5 +2,5 @@ User Control Component (95)
 ---------------------------
 
 This component was supposed to be used for mountable objects such as
-the `TEST Skateboard Mount <https://explorer.lu/objects/16684>`_
+the :lot:`TEST Skateboard Mount <16684>`
 which never saw the light of day.

--- a/docs/components/102-commendation-vendor.rst
+++ b/docs/components/102-commendation-vendor.rst
@@ -4,7 +4,7 @@ Commendation Vendor Component (102)
 This seems to be the component for a vendor that can sell you
 lost or deleted faction items for faction tokens. The only
 object this is attached to is
-`Honor Accolade -- Commendation Vendor <https://explorer.lu/objects/13806>`_.
+:lot:`Honor Accolade -- Commendation Vendor <13806>`.
 
 More information on him may be found here:
 `Honor Accolade <http://legouniverse.wikia.com/wiki/Honor_Accolade>`_

--- a/docs/components/116-culling-plane.rst
+++ b/docs/components/116-culling-plane.rst
@@ -3,4 +3,4 @@ Culling Plane Component (116)
 
 Components with this object ar supposed to occlude other objects behind them.
 The only object in the database with this component is
-`Culling Plane <https://explorer.lu/objects/16512>`_
+:lot:`Culling Plane <16512>`

--- a/docs/game-mechanics/flag-system.rst
+++ b/docs/game-mechanics/flag-system.rst
@@ -151,9 +151,9 @@ Known Flags
     119, Placed first model on AG medium property, 1.4.49 client
     120, No login fade on load, 1.4.49 client
     121, CP Sheild Generator flag, 1.4.49 client
-    801, :lot:`Elephant Pet - 3050 <3050>`, 1.1.18 client
+    801, :lot:`Elephant Pet <3050>`, 1.1.18 client
     802, Not used, 1.1.18 client
-    803, :lot:`Triceratops Pet - 3195 <3195>`, 1.1.18 client
+    803, :lot:`Triceratops Pet <3195>`, 1.1.18 client
     804, Reindeer - not in live 1, 1.1.18 client
     805, not used, 1.1.18 client
     806, Skunk Pet -, 1.1.18 client

--- a/docs/game-mechanics/mission-system.rst
+++ b/docs/game-mechanics/mission-system.rst
@@ -65,7 +65,7 @@ UseSkill (10)
 
 The player needs to trigger :samp:`targetValue` skill(s) from the comma-delimited set in :samp:`taskParam1`.
 
-Example: https://explorer.lu/missions/755
+Example :mis:`mission<755>`.
 
 ObtainItem (11)
 ^^^^^^^^^^^^^^^
@@ -94,7 +94,7 @@ Achieve at least :samp:`targetValue` at the :samp:`targetGroup` statistic in a m
 
 Example: https://explorer.lu/activities/5
 
-Some minigame missions like https://explorer.lu/missions/229 set their :samp:`targetValue` to `1` or `true`
+Some minigame missions like :mis:`mission 229 <229>`set their :samp:`targetValue` to `1` or `true`
 instead of setting them to their :samp:`targetValue` since you are intended to get this score in one attempt.
 
 Interact (15)


### PR DESCRIPTION
Should the base site for explorer.lu change it would now only need to be changed in the conf.py file instead of everywhere 1 at a time.