### PR TITLE
Added space to fix link to mission 755

### DIFF
--- a/docs/game-mechanics/mission-system.rst
+++ b/docs/game-mechanics/mission-system.rst
@@ -65,7 +65,7 @@ UseSkill (10)
 
 The player needs to trigger :samp:`targetValue` skill(s) from the comma-delimited set in :samp:`taskParam1`.
 
-Example :mis:`mission<755>`.
+Example :mis:`mission <755>`.
 
 ObtainItem (11)
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Missed a space when using conf.py to create this hyperlink which caused the creation of the link to fail.

tested on chrome and link correctly renders and links to mission 755