### PR TITLE
Add RegEx for a packet link

### DIFF
--- a/docs/components/004-character.rst
+++ b/docs/components/004-character.rst
@@ -26,7 +26,7 @@ Component Construction
 | :ref:`Possession Control <110-construction>`
 | :ref:`Level Progression <109-construction>`
 | :ref:`Player Forced Movement <106-construction>`
-| :packet:`raknet/client/replica/character/struct.CharacterConstruction`
+| :packet:`Character <raknet/client/replica/character/struct.CharacterConstruction>`
 
 Component Serialization
 .......................
@@ -34,7 +34,7 @@ Component Serialization
 | :ref:`Possession Control <110-serialization>`
 | :ref:`Level Progression <109-serialization>`
 | :ref:`Player Forced Movement <106-serialization>`
-| :packet:`raknet/client/replica/character/struct.CharacterSerialization`
+| :packet:`Character <raknet/client/replica/character/struct.CharacterSerialization>`
 
 Component XML Format
 ............................

--- a/docs/components/011-item.rst
+++ b/docs/components/011-item.rst
@@ -9,3 +9,18 @@ Relevant Database Tables
 ........................
 
 This component uses the :doc:`../database/ItemComponent` table.
+
+
+.. _011-construction:
+
+Component Construction
+......................
+
+| :packet:`Item <raknet/client/replica/item/struct.ItemConstruction>`
+
+.. _011-serialization:
+
+Component Serialization
+.......................
+
+| :packet:`Item <raknet/client/replica/item/type.ItemSerialization>`

--- a/docs/components/106-player-forced-movement.rst
+++ b/docs/components/106-player-forced-movement.rst
@@ -11,11 +11,11 @@ normal movement speed skateboard.
 Component Construction
 ......................
 
-:packet:`raknet/client/replica/player_forced_movement/struct.PlayerForcedMovementConstruction`
+| :packet:`Player Forced Movement <raknet/client/replica/player_forced_movement/struct.PlayerForcedMovementConstruction>`
 
 .. _106-serialization:
 
 Component Serialization
 .......................
 
-:packet:`raknet/client/replica/player_forced_movement/type.PlayerForcedMovementConstruction`
+| :packet:`Player Forced Movement <raknet/client/replica/player_forced_movement/type.PlayerForcedMovementSerialization>`

--- a/docs/components/109-level-progression.rst
+++ b/docs/components/109-level-progression.rst
@@ -19,12 +19,12 @@ Relevant Game Messages
 Component Construction
 ......................
 
-:packet:`raknet/client/replica/level_progression/struct.LevelProgressionConstruction`
+| :packet:`Level Progression <raknet/client/replica/level_progression/struct.LevelProgressionConstruction>`
 
 .. _109-serialization:
 
 Component Serialization
 .......................
 
-:packet:`raknet/client/replica/level_progression/type.LevelProgressionConstruction`
+| :packet:`Level Progression <raknet/client/replica/level_progression/type.LevelProgressionSerialization>`
 

--- a/docs/components/110-possession-control.rst
+++ b/docs/components/110-possession-control.rst
@@ -17,11 +17,11 @@ Relevant Game Messages
 Component Construction
 ......................
 
-:packet:`raknet/client/replica/possession_control/struct.PossessionControlConstruction`
+| :packet:`Possession Control <raknet/client/replica/possession_control/struct.PossessionControlConstruction>`
 
 .. _110-serialization:
 
 Component Serialization
 .......................
 
-:packet:`raknet/client/replica/possession_control/type.PossessionControlSerialization`
+| :packet:`Possession Control <raknet/client/replica/possession_control/type.PossessionControlSerialization>`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,11 +110,9 @@ def wiki_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
     node = nodes.reference(rawtext, title, refuri=ref, **options)
     return [node], []
 
-packet_matcher = re.compile(r"(.*) <(.*)>")
-# Takes a string like raknet/client/replica/character/struct.CharacterSerialization and returns CharacterSerialization with .findall
-default_name_finder = re.compile(r"((?:[A-Z][^A-Z]*(?!\\))+$)")
-# Takes a string like CharacterSerialization and returns ['Character', 'Serialization'] with .findall
-default_name_splitter = re.compile(r"([A-Z][^A-Z]*)")
+# There is supposed to be a way to do this in Sphinx, but I cannot figure it out.
+# This covers our base cases but should be replaced when the real method is able to be done.
+packet_matcher = re.compile(r'(.*) <(.*)>')
 
 def lu_packet_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
     m = packet_matcher.match(text)
@@ -124,8 +122,10 @@ def lu_packet_role(role, rawtext, text, lineno, inliner, options={}, content=[])
         new_url = m.group(2)
         new_title = m.group(1)
     else:
-        name_split = re.findall(default_name_splitter, re.findall(default_name_finder, text)[0])
-        new_title = " ".join(name_split)
+        name_split = text.split(".")
+        if len(name_split) < 2:
+            raise ValueError('Packet link (%s) is not valid' % text)
+        new_title = name_split[1]
     ref = lu_packet_base_url + '%s.html' % new_url
     set_classes(options)
     title = utils.unescape(new_title)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,10 +125,7 @@ def lu_packet_role(role, rawtext, text, lineno, inliner, options={}, content=[])
         new_title = m.group(1)
     else:
         name_split = re.findall(default_name_splitter, re.findall(default_name_finder, text)[0])
-        new_title = ""
-        for word in name_split:
-            new_title += word + " "
-        new_title = new_title[:-1]
+        new_title = " ".join(name_split)
     ref = lu_packet_base_url + '%s.html' % new_url
     set_classes(options)
     title = utils.unescape(new_title)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -110,10 +110,28 @@ def wiki_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
     node = nodes.reference(rawtext, title, refuri=ref, **options)
     return [node], []
 
+packet_matcher = re.compile(r"(.*) <(.*)>")
+# Takes a string like raknet/client/replica/character/struct.CharacterSerialization and returns CharacterSerialization with .findall
+default_name_finder = re.compile(r"((?:[A-Z][^A-Z]*(?!\\))+$)")
+# Takes a string like CharacterSerialization and returns ['Character', 'Serialization'] with .findall
+default_name_splitter = re.compile(r"([A-Z][^A-Z]*)")
+
 def lu_packet_role(role, rawtext, text, lineno, inliner, options={}, content=[]):
-    ref = lu_packet_base_url + '%s.html' % text
+    m = packet_matcher.match(text)
+    new_url = text
+    new_title = text
+    if m:
+        new_url = m.group(2)
+        new_title = m.group(1)
+    else:
+        name_split = re.findall(default_name_splitter, re.findall(default_name_finder, text)[0])
+        new_title = ""
+        for word in name_split:
+            new_title += word + " "
+        new_title = new_title[:-1]
+    ref = lu_packet_base_url + '%s.html' % new_url
     set_classes(options)
-    title = utils.unescape(text)
+    title = utils.unescape(new_title)
     node = nodes.reference(rawtext, title, refuri=ref, **options)
     return [node], []
 

--- a/docs/game-mechanics/properties/naming-and-describing-models.rst
+++ b/docs/game-mechanics/properties/naming-and-describing-models.rst
@@ -17,15 +17,15 @@ The following diagram shows the expected reply from a server in order to succeed
     WorldServer -> Client: [<b>Item Component Serialization</b>] Description updated with moderated description
     @enduml
 
-Networked message definitions:
+Networked message definitions
 
 * Game Message :gm:server:`UpdatePropertyOrModelForFilterCheck`
 
 * Game Message :gm:client:`SetName`
 
-Component serialization:
+Component serialization
 
-* Item Component :packet:`raknet/client/replica/item/struct.ItemConstruction`
+* :ref:`011-serialization`
 
 Until the SetName message **and** Item Component serialization are sent, the client will be
 unable to name or describe models until a time out occurs, upon which the client side name and description will revert
@@ -37,8 +37,8 @@ The following will happen if the client does not receive **both** of these repli
 * The description will not be updated unless the Item Component Serialized with the moderated description. 
 
 
-What should happen after receiving the Client message:
-------------------------------------------------------
+What should happen after receiving the Client message
+-----------------------------------------------------
 
 If a user successfully changes the name and/or description and the values are approved and are different from their defaults,
 the model should become a user generated model and lose its default model property so that the name can be preserved


### PR DESCRIPTION
Add a default RegEx for a packet link like `raknet/client/replica/character/struct.CharacterSerialization` to have a default title of `Character Serialization`

Allow for custom packet names by using the same logic as explorer uses.  Any character, followed by the actual argument in angle brackets will result in the text to the left of the angle brackets to be shown as the title instead of the raw URL.