### PR TITLE
Fix serialization and definitions in Basic Attack Behavior

### DIFF
--- a/docs/game-mechanics/behaviors/basic-attack.rst
+++ b/docs/game-mechanics/behaviors/basic-attack.rst
@@ -25,7 +25,7 @@ Parameters
    * - min damage
      - The minimum amount of damage to be dealt.
    * - on_fail_armor
-     - The behavior to use on failure due to armor.
+     - The behavior to use on failure due to the target having armor.
    * - on_fail_blocked
      - The behavior to use on failure due to the attack being blocked.
    * - on_fail_immune
@@ -37,22 +37,9 @@ Parameters
    * - use_caster_velocity
      - Whether or not to use the casters velocity.
    * - velocity_multiplier
-     - Value to multiply velocity by when attacking.
+     - Value to multiply velocity by when attacking(?).
 
-Darkflame Universe Parameter Notes
-----------------------------------
-
-As of February 11, 2022, only the following parameters are used:
-
-- max damage
-- min damage
-- on_success
-
-It is unknown whether the following need to be used:
-
-- on_fail_armor
-- on_fail_blocked
-- on_fail_immune
+It is unknown what the following variables are used for:
 - dont_apply_immune
 - dir_angle_xz
 - dir_angle_y
@@ -66,19 +53,12 @@ BitStream Serialization
 
 Align to byte boundary.
 
-| **[u16]** - Required BitStream Padding.
+| **[u16]** - Number of bits used for this basic attack serialization.  ex. If the attack was blocked, then this would be 1
 | **[bit]** - True if the attack was blocked, false otherwise.
 | **[bit]** - True if the the target is immune, false otherwise.
 | **[bit]** - True if the attack was successful, false otherwise.
-| **[u32]** - Required BitStream Padding.
-| **[u32]** - Amount of damage that was dealt.
-| **[bit]** - True if the target died from the attack.  False otherwise.
+| if successful attack:
+|   **[u32]** - Required BitStream Padding.
+|   **[u32]** - Amount of damage that was dealt.
+|   **[bit]** - True if the target died from the attack.  False otherwise.
 | **[u8]**  - The success state of the attack.
-
-DarkFlame Universe Server Side Calculation Notes
-------------------------------------------------
-
-- The aligning to byte boundary must be done.  The meaning of this alignment is currently unknown.
-- The padding in the BitStream is required.  The meaning of the padding is also unknown.
-- The attack is never blocked, the target is never immune and the attack is always successful.
-- The success state is always serialized as 1 as of February 11, 2022.


### PR DESCRIPTION
Fix serialization and definitions in Basic Attack behavior that were incorrect.  Define unknown values.  Remove DLU specific notes.