### PR TITLE
Fix consistency warnings and unlinked gm

### DIFF
--- a/docs/components/009-skill.rst
+++ b/docs/components/009-skill.rst
@@ -23,7 +23,7 @@ This component uses the following tables:
 Relevant Game Messages
 ......................
 
-* `gm-echo-start-skill`
+* :gm:client:`EchoStartSkill`
 * :gm:server:`StartSkill`
 * :gm:server:`SelectSkill`
 * :gm:client:`AddSkill`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,7 +72,7 @@ language = "en"
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This patterns also effect to html_static_path and html_extra_path
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'res']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'res', 'venv/*']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
Fixes consistency warnings with files in venv and links to a gm on lcdrs' site