### PR TITLE
Fix inconsistency with double colons

### DIFF
--- a/docs/components/004-character.rst
+++ b/docs/components/004-character.rst
@@ -102,7 +102,7 @@ Component XML Format
 
 .. _lzid_foot_note:
 
-.. note ::
+.. note::
   | :samp:`lzid` a binary concatenation of world ID, world instance and world clone, e.g:
   | lzid = :samp:`2341502167811299`
   | hex representation of lzid = :samp:`00 08 51 95 74 f4 04 e3`

--- a/docs/components/009-skill.rst
+++ b/docs/components/009-skill.rst
@@ -32,7 +32,7 @@ Relevant Game Messages
 XML Serialization :samp:`<skil>`
 ................................
 
-.. note ::
+.. note::
   What kind of skills, active ones? Why would they be saved? Action bar skills and skill uses are handled using different packets, so what would this be?
 
 This was empty in the packet, if you find a sample that isn't empty please add content.

--- a/docs/components/084-mission.rst
+++ b/docs/components/084-mission.rst
@@ -3,7 +3,7 @@ Mission Component (84)
 
 This component is responsible for missions and achievements.
 
-.. note ::
+.. note::
   This component is not attached to any object in the game database.
 
 Relevant Game Messages

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,1 +1,1 @@
-.. include :: ../CONTRIBUTING.rst
+.. include:: ../CONTRIBUTING.rst

--- a/docs/database/CurrencyDenominations.rst
+++ b/docs/database/CurrencyDenominations.rst
@@ -5,7 +5,7 @@ This table contains the games coin currency denominations.
 Each row maps a currency amount to a LOT which is the item that is spawned when said value is dropped.
 An example is the :lot:`LOT for one coin <163>` which is what is spawned when 1 coin is dropped.
 
-.. list-table ::
+.. list-table::
    :widths: 15 15 20
    :header-rows: 1
 

--- a/docs/database/LevelProgressionLookup.rst
+++ b/docs/database/LevelProgressionLookup.rst
@@ -4,7 +4,7 @@ LevelProgressionLookup
 This table contains a level and the uscore required to be that level.
 All :samp:`BehaviorEffect` columns are empty.
 
-.. list-table ::
+.. list-table::
    :widths: 15 15 30
    :header-rows: 1
 

--- a/docs/database/PlayerFlags.rst
+++ b/docs/database/PlayerFlags.rst
@@ -3,7 +3,7 @@ PlayerFlags
 
 Configuration for the :doc:`../game-mechanics/flag-system`.
 
-.. list-table ::
+.. list-table::
    :widths: 15 15 20
    :header-rows: 1
 

--- a/docs/database/Preconditions.rst
+++ b/docs/database/Preconditions.rst
@@ -25,7 +25,7 @@ gate_version                                        TEXT
 Column :samp:`type`
 ^^^^^^^^^^^^^^^^^^^
 
-.. csv-table ::
+.. csv-table::
     :widths: 10,90
 
     0, Item Equipped

--- a/docs/database/VendorComponent.rst
+++ b/docs/database/VendorComponent.rst
@@ -4,7 +4,7 @@ VendorComponent
 This table tells a Vendor Component information about the vendor.
 The loot matrix index is the items the vendor sells, for example.
 
-.. list-table ::
+.. list-table::
    :widths: 15 15 20
    :header-rows: 1
 

--- a/docs/file-structures.rst
+++ b/docs/file-structures.rst
@@ -1,7 +1,7 @@
 Introduction
 ------------
 
-.. note ::
+.. note::
 	This is a read-the-docs port of the original google docs `lu_file_structs <https://docs.google.com/document/d/1ZlgGv5gVI7Rx6kGNUwoXDHhOKJNjHkfQcuzpCL_fgjw>`_, written by humanoid, lcdr and others, ported by `@Xiphoseer <https://twitter.com/Xiphoseer>`_. This is currently a proof of concept and is not guaranteed to reflect the latest changes.
 
 

--- a/docs/file-structures/catalog.rst
+++ b/docs/file-structures/catalog.rst
@@ -1,7 +1,7 @@
 Catalog (.pki)
 ^^^^^^^^^^^^^^
 
-.. note ::
+.. note::
 
 	* The game had the majority of its data files packed in a custom dynamic archive. Within that system, each file was identified by the CRC-32 value of its filename relative to the installation root.
 	* The crc value uses the standard CRC-32 polynomial `0x04C11DB7`, an init value of `0xFFFFFFFF`, no output XOR and reverses neither input nor output. The filenames are processed in lowercase, with Win32 ``\`` delimiters and a padding of 4 `0x00` bytes at the end.

--- a/docs/file-structures/database.rst
+++ b/docs/file-structures/database.rst
@@ -3,10 +3,10 @@ Database (.fdb)
 
 You can use the tools collection from `assembly <https://crates.io/crates/assembly-data>`_ to work with FDB files.
 
-.. note ::
+.. note::
 	There is a converter from fdb to sqlite available, see the :ref:`tools` section. This file type has no relation to firebird database files of the same extension.
 
-.. note ::
+.. note::
 	It seems like:
 		* Tables are sorted by their name in ascii representation. Uppercase letters then underscore then lowercase letters.
 		* Tables themselves are hash maps. Use `id % row_count` to get the appropriate `row_info`, then follow the `linked_row_info` until all entries with that ID are found.
@@ -15,7 +15,7 @@ You can use the tools collection from `assembly <https://crates.io/crates/assemb
 
 .. kaitai:: ../res/lu_formats/files/fdb.ksy
 
-.. note ::
+.. note::
 	* Address pointers can be -1 which most likely means an invalid address (just skip those)
 	* Strings types (TEXT and VARCHAR) are always null-terminated (with some over allocated bytes afterwards it seems, apparently string length are filled to be modulo 4 = 0?)
 	* Strings and int64 (BIGINT) types are always stored with an additional address pointer, like this: [pointer]->[data]
@@ -26,7 +26,7 @@ SQLite Conversion
 lcdr's tools rely on https://www.sqlite.org/datatype3.html#determination_of_column_affinity to assign the type
 of columns in SQLite while preserving the original type:
 
-.. code-block :: py
+.. code-block:: python
 
 	SQLITE_TYPE = {}
 	SQLITE_TYPE[0] = "none"

--- a/docs/file-structures/level.rst
+++ b/docs/file-structures/level.rst
@@ -1,7 +1,7 @@
 Level (.lvl)
 ^^^^^^^^^^^^
 
-.. note ::
+.. note::
 
 	* It seems the structure is split in chunks marked by “CHNK”, somewhat similar to the IFF file format
 	* It seems Chunks can only begin on addresses % 16 == 0, if the chunk wouldn’t start on one padding is inserted until it matches 

--- a/docs/file-structures/lutriggers.rst
+++ b/docs/file-structures/lutriggers.rst
@@ -19,7 +19,7 @@ plain text, xml structure
 Possible Values (EventIDs)
 --------------------------
 
-.. hlist ::
+.. hlist::
 	:columns: 3
 
 	* OnDestroy

--- a/docs/file-structures/other.rst
+++ b/docs/file-structures/other.rst
@@ -18,6 +18,6 @@ Plain text, lists paths to additional files (to load?), one line for each file
 Animations (.gfx)
 ^^^^^^^^^^^^^^^^^
 
-.. note ::
+.. note::
 	Used for small animations, such as minifig faces. Essentially a .swf flash file, with a different file header. To convert to a .swf file, change the “GFX” in the beginning of the file header to “FWS”.
 	See also: http://wwwimages.adobe.com/content/dam/Adobe/en/devnet/swf/pdf/swf-file-format-spec.pdf

--- a/docs/file-structures/segmented.rst
+++ b/docs/file-structures/segmented.rst
@@ -10,7 +10,7 @@ compression process also generated :any:`ff-si0` files to be used when creating 
 Segmented Data (.sd0)
 ^^^^^^^^^^^^^^^^^^^^^
 
-.. note :: There is a decompressor available, see the :any:`tools` section.
+.. note:: There is a decompressor available, see the :any:`tools` section.
 
 | **[L:5]** - header, ‘s’-‘d’-‘0’-01-ff
 | repeated:

--- a/docs/game-mechanics.rst
+++ b/docs/game-mechanics.rst
@@ -1,7 +1,7 @@
 Game Mechanics
 ==============
 
-.. note ::
+.. note::
 	This is a read-the-docs port of the original google docs `lu_game_mechanics <https://docs.google.com/document/d/1kMr41wJP88PpTLhPZ1zE8dJUF3yYGHuZENa_WjHzXG4>`_, written by humanoid, lcdr and others, ported by `@Xiphoseer <https://twitter.com/Xiphoseer>`_. This is currently a proof of concept and is not guaranteed to reflect the latest changes.
 
 .. toctree::

--- a/docs/game-mechanics/behaviors/air-movement.rst
+++ b/docs/game-mechanics/behaviors/air-movement.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -42,9 +42,9 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate
 
-.. note ::
+.. note::
    like Attack Delay, this causes SyncSkill messages, which use the behavior handle as ID
    but have the behavior to execute specified in the SyncSkill bitstream
 

--- a/docs/game-mechanics/behaviors/alter-chain-delay.rst
+++ b/docs/game-mechanics/behaviors/alter-chain-delay.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -20,4 +20,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/alter-cooldown.rst
+++ b/docs/game-mechanics/behaviors/alter-cooldown.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -20,4 +20,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/aoe.rst
+++ b/docs/game-mechanics/behaviors/aoe.rst
@@ -6,7 +6,7 @@ This behavior calls the specified action on all / a maximum number of entities i
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/apply-buff.rst
+++ b/docs/game-mechanics/behaviors/apply-buff.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/attack-delay.rst
+++ b/docs/game-mechanics/behaviors/attack-delay.rst
@@ -13,7 +13,7 @@ See the diagram in :doc:`../skill-system` for a diagram on how this interaction 
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/basic-attack.rst
+++ b/docs/game-mechanics/behaviors/basic-attack.rst
@@ -6,7 +6,7 @@ This behavior is used to deal damage to a target.
 Parameters 
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -56,7 +56,7 @@ Align to the byte boundary
 | **[u16]** - Number of bits used for this basic attack serialization and all sub-branches. (referred to as :samp:`allocatedSize`)
 | Save the offset at this position for use later (referred to here as :samp:`startOffset`)
 
-.. note ::
+.. note::
   | If the target blocked the attack, this value would be a 1. If the target was immune it would be a 2. If the success state branches are reached, then this value also represents the
   | sum of all the sub behaviors!  
 
@@ -85,7 +85,7 @@ Align to the byte boundary
 |       :samp:`on_fail_immune`
 | align the bitStream to :samp:`startOffset + allocatedSize` and return
 
-.. note ::
+.. note::
  | For serializing the behavior, the success state is determined as follows:
  | if *any* health damage was done at all, the success state is 1.
  | if *zero* health damage was done and armor damage is greater than zero, the success state is 2. Has one caveat mentioned below.

--- a/docs/game-mechanics/behaviors/block.rst
+++ b/docs/game-mechanics/behaviors/block.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -28,4 +28,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/buff.rst
+++ b/docs/game-mechanics/behaviors/buff.rst
@@ -6,7 +6,7 @@ Increases the player stats while the behavior is active
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/camera.rst
+++ b/docs/game-mechanics/behaviors/camera.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -34,4 +34,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/car-boost.rst
+++ b/docs/game-mechanics/behaviors/car-boost.rst
@@ -6,7 +6,7 @@ Boost a car?
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/chain.rst
+++ b/docs/game-mechanics/behaviors/chain.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/change-idle-flags.rst
+++ b/docs/game-mechanics/behaviors/change-idle-flags.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/change-orientation.rst
+++ b/docs/game-mechanics/behaviors/change-orientation.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -30,7 +30,7 @@ Parameters
 Possibly deprecated
 -------------------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -46,4 +46,4 @@ Possibly deprecated
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/charge-up.rst
+++ b/docs/game-mechanics/behaviors/charge-up.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -20,4 +20,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/clear-target.rst
+++ b/docs/game-mechanics/behaviors/clear-target.rst
@@ -3,7 +3,7 @@ Clear Target (62)
 
 Details unknown
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -17,4 +17,4 @@ Details unknown
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/consume-item.rst
+++ b/docs/game-mechanics/behaviors/consume-item.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/damage-reduction.rst
+++ b/docs/game-mechanics/behaviors/damage-reduction.rst
@@ -3,7 +3,7 @@ Damage Reduction (60)
 
 Details unknown
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -15,4 +15,4 @@ Details unknown
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/dark-inspiration.rst
+++ b/docs/game-mechanics/behaviors/dark-inspiration.rst
@@ -4,7 +4,7 @@ Dark Inspiration (24)
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/duration.rst
+++ b/docs/game-mechanics/behaviors/duration.rst
@@ -6,7 +6,7 @@ This behavior describes that the subsequent ones are active (only) for some stre
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -22,7 +22,7 @@ Parameters
 Possibly deprecated
 ^^^^^^^^^^^^^^^^^^^
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -36,7 +36,7 @@ Possibly deprecated
 Likely errors
 ^^^^^^^^^^^^^
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/end.rst
+++ b/docs/game-mechanics/behaviors/end.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -20,4 +20,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/fall-speed.rst
+++ b/docs/game-mechanics/behaviors/fall-speed.rst
@@ -4,7 +4,7 @@ Fall Speed (20)
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/force-movement.rst
+++ b/docs/game-mechanics/behaviors/force-movement.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/grab.rst
+++ b/docs/game-mechanics/behaviors/grab.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -22,4 +22,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/heal.rst
+++ b/docs/game-mechanics/behaviors/heal.rst
@@ -6,7 +6,7 @@ This behavior is used to heal an object.
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/imagination.rst
+++ b/docs/game-mechanics/behaviors/imagination.rst
@@ -6,7 +6,7 @@ This behavior is used to restore imagination for an object.
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -18,4 +18,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: Figure out serialization
+.. todo:: Figure out serialization

--- a/docs/game-mechanics/behaviors/imitation-skunk-stink.rst
+++ b/docs/game-mechanics/behaviors/imitation-skunk-stink.rst
@@ -6,7 +6,7 @@ Details unknown
 Likely deprecated parameters
 ----------------------------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/immunity.rst
+++ b/docs/game-mechanics/behaviors/immunity.rst
@@ -6,7 +6,7 @@ This behavior grants the player/object immunity against some actions
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/interrupt.rst
+++ b/docs/game-mechanics/behaviors/interrupt.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/jetpack.rst
+++ b/docs/game-mechanics/behaviors/jetpack.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/knockback.rst
+++ b/docs/game-mechanics/behaviors/knockback.rst
@@ -6,7 +6,7 @@ This behavior results in a knockback effect on targeted players/enemies
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -27,7 +27,7 @@ Parameters
 Possibly deprecated
 ^^^^^^^^^^^^^^^^^^^
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/lay-brick.rst
+++ b/docs/game-mechanics/behaviors/lay-brick.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/loot-buff.rst
+++ b/docs/game-mechanics/behaviors/loot-buff.rst
@@ -7,7 +7,7 @@ The result of this behavior is serialized in the Controllable Physics Component 
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/modular-build.rst
+++ b/docs/game-mechanics/behaviors/modular-build.rst
@@ -11,4 +11,4 @@ This component has no parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/mount.rst
+++ b/docs/game-mechanics/behaviors/mount.rst
@@ -3,7 +3,7 @@ Mount (64)
 
 Details unknown
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -15,4 +15,4 @@ Details unknown
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/movement-switch.rst
+++ b/docs/game-mechanics/behaviors/movement-switch.rst
@@ -6,7 +6,7 @@ Calls different behaviors depending on what the current movement type of the ori
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/npc-combat-skill.rst
+++ b/docs/game-mechanics/behaviors/npc-combat-skill.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -24,7 +24,7 @@ Parameters
 Possible errors
 ^^^^^^^^^^^^^^^
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -36,4 +36,4 @@ Possible errors
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/over-time.rst
+++ b/docs/game-mechanics/behaviors/over-time.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/projectile-attack.rst
+++ b/docs/game-mechanics/behaviors/projectile-attack.rst
@@ -6,7 +6,7 @@ This behavior is used to launch a projectile that can hit other objects.
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/property-rotate.rst
+++ b/docs/game-mechanics/behaviors/property-rotate.rst
@@ -11,4 +11,4 @@ This behavior has no parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/property-teleport.rst
+++ b/docs/game-mechanics/behaviors/property-teleport.rst
@@ -3,7 +3,7 @@ Property Teleport (61)
 
 Details unknown
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -17,4 +17,4 @@ Details unknown
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/pull-to-point.rst
+++ b/docs/game-mechanics/behaviors/pull-to-point.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -20,4 +20,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/remove-buff.rst
+++ b/docs/game-mechanics/behaviors/remove-buff.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -20,4 +20,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/repair-armor.rst
+++ b/docs/game-mechanics/behaviors/repair-armor.rst
@@ -4,7 +4,7 @@ Repair Armor (22)
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/skill-cast-failed.rst
+++ b/docs/game-mechanics/behaviors/skill-cast-failed.rst
@@ -6,7 +6,7 @@ Details unknown
 Likely deprecated parameters
 ----------------------------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/skill-event.rst
+++ b/docs/game-mechanics/behaviors/skill-event.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/skill-set.rst
+++ b/docs/game-mechanics/behaviors/skill-set.rst
@@ -3,7 +3,7 @@ SkillSet (65)
 
 Details unknown
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -15,4 +15,4 @@ Details unknown
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/spawn-object.rst
+++ b/docs/game-mechanics/behaviors/spawn-object.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/spawn-quickbuild.rst
+++ b/docs/game-mechanics/behaviors/spawn-quickbuild.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -32,4 +32,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/speed.rst
+++ b/docs/game-mechanics/behaviors/speed.rst
@@ -4,7 +4,7 @@ Speed (23)
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/start.rst
+++ b/docs/game-mechanics/behaviors/start.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -20,4 +20,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/stun.rst
+++ b/docs/game-mechanics/behaviors/stun.rst
@@ -6,7 +6,7 @@ Temporarily removes the characters ability to do certain things
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -36,7 +36,7 @@ Parameters
 Possibly deprecated
 ^^^^^^^^^^^^^^^^^^^
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -56,7 +56,7 @@ Possibly deprecated
 Likely typos
 ^^^^^^^^^^^^
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/switch-multiple.rst
+++ b/docs/game-mechanics/behaviors/switch-multiple.rst
@@ -6,7 +6,7 @@ Details unknown, mostly used for charge up action
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -24,7 +24,7 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate
 
 | **[float]** - value
 | if value <= “value_1” parameter:

--- a/docs/game-mechanics/behaviors/switch.rst
+++ b/docs/game-mechanics/behaviors/switch.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/tac-arc.rst
+++ b/docs/game-mechanics/behaviors/tac-arc.rst
@@ -7,7 +7,7 @@ fit the given parameters.
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/take-picture.rst
+++ b/docs/game-mechanics/behaviors/take-picture.rst
@@ -3,7 +3,7 @@ Take Picture (63)
 
 Details unknown
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -19,4 +19,4 @@ Details unknown
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/target-caster.rst
+++ b/docs/game-mechanics/behaviors/target-caster.rst
@@ -6,7 +6,7 @@ Set the caster as the target for subsequent actions.
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -18,6 +18,6 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: Figure out serialization
+.. todo:: Figure out serialization
 
 | -> action

--- a/docs/game-mechanics/behaviors/taunt.rst
+++ b/docs/game-mechanics/behaviors/taunt.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -18,4 +18,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/behaviors/venture-vision.rst
+++ b/docs/game-mechanics/behaviors/venture-vision.rst
@@ -7,7 +7,7 @@ Pet digs seem to be disabled altogether however.
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 15 30
    :header-rows: 1
 

--- a/docs/game-mechanics/behaviors/verify.rst
+++ b/docs/game-mechanics/behaviors/verify.rst
@@ -6,7 +6,7 @@ Details unknown
 Parameters
 ----------
 
-.. list-table ::
+.. list-table::
    :widths: 15 30
    :header-rows: 1
 
@@ -26,4 +26,4 @@ Parameters
 BitStream Serialization
 -----------------------
 
-.. todo :: investigate
+.. todo:: investigate

--- a/docs/game-mechanics/kit-factions.rst
+++ b/docs/game-mechanics/kit-factions.rst
@@ -19,7 +19,7 @@ Missions
 
 The following missions control the faction missions:
 
-.. csv-table ::
+.. csv-table::
 
     venture, :mis:`555`, :mis:`556`, :mis:`778`
     assembly, :mis:`544`, :mis:`545`, :mis:`778`

--- a/docs/game-mechanics/mission-system.rst
+++ b/docs/game-mechanics/mission-system.rst
@@ -84,7 +84,7 @@ the items at mission turn in.  Depending on :samp:`taskParam1`:
 | - 1: The :samp:`target` item is not taken from the players inventory on mission turn in.
 | - 2: The :samp:`target` item is taken from the players inventory on mission turn in.
 
-.. note ::
+.. note::
   | Items are only ever removed from the inventory types ITEMS and HIDDEN, should they need to be removed
 
 | - 5: Items are not taken from the inventory nor will losing these items before the mission is completed decrement progress.
@@ -150,7 +150,7 @@ Depending on :samp:`taskParam1`:
 | - 14: Win :samp:`targetValue` races at the world specified by :samp:`target`.
 | - 15: Win :samp:`targetValue` races at the worlds specified by :samp:`targetGroup`.
 
-.. note ::
+.. note::
   | Task type 15 is a bitflag!  The number of bits that are on dictates the progress of the mission.
 
 | - 16: Finish in last place :samp:`targetValue` times in :samp:`targetGroup` race worlds.

--- a/docs/game-mechanics/properties.rst
+++ b/docs/game-mechanics/properties.rst
@@ -1,7 +1,7 @@
 Properties
 ==========
 
-.. note ::
+.. note::
 	This is a read-the-docs port of the original google docs `lu_game_mechanics <https://docs.google.com/document/d/1kMr41wJP88PpTLhPZ1zE8dJUF3yYGHuZENa_WjHzXG4>`_, written by humanoid, lcdr and others, ported by `@Xiphoseer <https://twitter.com/Xiphoseer>`_. This is currently a proof of concept and is not guaranteed to reflect the latest changes.
 
 .. toctree::

--- a/docs/game-mechanics/skill-system.rst
+++ b/docs/game-mechanics/skill-system.rst
@@ -26,7 +26,7 @@ When a behavior is not completed immediately, it will serialize a :samp:`handleI
 later be used to identify a :gm:server:`SyncSkill` message that serializes the continued execution. It
 is possible that this happens multiple times for a single skill execution.
 
-.. uml ::
+.. uml::
 
    @startuml
    Client -> Server: StartSkill

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@
 Welcome to the LEGO Universe technical documentation!
 =====================================================
 
-.. note ::
+.. note::
 	This is a read-the-docs port of `lu_packet_structs <https://docs.google.com/document/d/1v9GB1gNwO0C81Rhd4imbaLN7z-R0zpK5sYJMbxPP3Kc>`_, written by humanoid, lcdr and others on Google Docs. It was ported by `@Xiphoseer <https://twitter.com/Xiphoseer>`_. This is currently a proof of concept and is not guaranteed to reflect the latest changes.
 
 The purpose of this documentation is to list and protocol all the information about the network packets of the game LEGO Universe. For organization purposes the contents of the documentation is extended to the following documents:
@@ -58,7 +58,7 @@ The purpose of this documentation is to list and protocol all the information ab
 
 If any of these documents helped you in some way or another for one of your projects, please credit us and/or include a direct link to this document!
 
-.. warning ::
+.. warning::
 
 	Neither the original documentation nor this read-the-docs port is associated or involved with The LEGO Group.
 	Likewise, the creators of the aforementioned documents are not associated or involved with The LEGO Group.

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -1,7 +1,7 @@
 Introduction
 ============
 
-.. note ::
+.. note::
 	This is a read-the-docs port of the original google docs `lu_packet_structs <https://docs.google.com/document/d/1v9GB1gNwO0C81Rhd4imbaLN7z-R0zpK5sYJMbxPP3Kc>`_, written by humanoid, lcdr and others, ported by `@Xiphoseer <https://twitter.com/Xiphoseer>`_. This is currently a proof of concept and is not guaranteed to reflect the latest changes.
 
 Quick notes to get started

--- a/docs/packets/common.rst
+++ b/docs/packets/common.rst
@@ -1,4 +1,4 @@
 Common Structures
 ^^^^^^^^^^^^^^^^^
 
-.. kaitai :: ../res/lu_formats/packets/net.ksy
+.. kaitai:: ../res/lu_formats/packets/net.ksy

--- a/docs/packets/general.rst
+++ b/docs/packets/general.rst
@@ -1,4 +1,4 @@
 General
 ^^^^^^^
 
-.. kaitai :: ../res/lu_formats/packets/general.ksy
+.. kaitai:: ../res/lu_formats/packets/general.ksy

--- a/docs/replica.rst
+++ b/docs/replica.rst
@@ -1,10 +1,10 @@
 Replica Packets
 =============== 
 
-.. note ::
+.. note::
 	This is a read-the-docs port of the original google docs `lu_replica_packets <https://docs.google.com/document/d/1V_yhtj91QG0VBfMnmD5zC44DXwCRqjbBN98HoXXC7qs>`_, written by humanoid, lcdr and others, ported by `@Xiphoseer <https://twitter.com/Xiphoseer>`_. This is currently a proof of concept and is not guaranteed to reflect the latest changes.
 
-.. note ::
+.. note::
 	- most structures can be omitted if they are optional, so you do not have to implement everything
 	- grey colored structs didn’t occur in a packet yet
 	- for investigations in raw replica packets, an advanced hex editor that can do bit operations on the data is very much recommended since there tend to be a lot of bit shifts in one packet


### PR DESCRIPTION
Currently in an editor, these appear as comments when these are intended to be interpreted as blocks of notes or todos.

No change in functionality but this is consistent with the style standard now