### PR TITLE
Add unused UI interface lua calls

### DIFF
--- a/docs/game-mechanics/scripting-system.rst
+++ b/docs/game-mechanics/scripting-system.rst
@@ -85,6 +85,9 @@ UI
 --
 
 - UI:SendMessage(msg: string, data: NDGfxValue)
+- UI:SendChat(ChatString: string, ChatType: int, Timestamp: int)
+- UI:DisplayToolTip(strDialogText: string, strImageName: string, bShow: boolean, iTime: int)
+- UI:CallService(serviceName: string, data: NDGFxValue)
 
 Timer
 -----


### PR DESCRIPTION
Found these looking though the client since they are unused in lua.  Their handlers seem to still be there so its possible they still work and would allow us to learn more from the exposed interface