### PR TITLE
Correct OnDeactivated to OnDectivated

### DIFF
--- a/docs/file-structures/lutriggers.rst
+++ b/docs/file-structures/lutriggers.rst
@@ -31,7 +31,7 @@ Possible Values (EventIDs)
 	* OnTimerDone
 	* OnRebuildComplete
 	* OnActivated
-	* OnDeactivated
+	* OnDectivated
 	* OnArrived
 	* OnArrivedAtEndOfPath
 	* OnZoneSummaryDismissed

--- a/docs/file-structures/lutriggers.rst
+++ b/docs/file-structures/lutriggers.rst
@@ -31,7 +31,7 @@ Possible Values (EventIDs)
 	* OnTimerDone
 	* OnRebuildComplete
 	* OnActivated
-	* OnDectivated
+	* OnDectivated [sic]
 	* OnArrived
 	* OnArrivedAtEndOfPath
 	* OnZoneSummaryDismissed


### PR DESCRIPTION
In the client and in all lutriggers, it is spelled `OnDectivated` not `OnDeactivated`