### PR TITLE
Link to the correct LOT reference for LWO...Component names

### DIFF
--- a/docs/components.rst
+++ b/docs/components.rst
@@ -6,7 +6,7 @@ to how the object gets serialized from the server to the client, but also attach
 functionality and behaviors to the object. Components may react to game messages but also express
 other aspects of the game.
 
-As per :lot:`this test object's description <3050>`,
+As per :lot:`this test object's description <6228>`,
 the internal name of a component class would have been :file:`LWO{Name}Component` as in
 :samp:`LWOModelBuilderComponent`.
 


### PR DESCRIPTION
Correct reference is lot 6228.  3050 does not reference LWO...Component.